### PR TITLE
fix aged images and otel configuration

### DIFF
--- a/observability/alerting/.env
+++ b/observability/alerting/.env
@@ -1,2 +1,2 @@
-OTELCOL_IMG=otel/opentelemetry-collector-contrib-dev:latest
+OTELCOL_IMG=otel/opentelemetry-collector:latest
 OTELCOL_ARGS=

--- a/observability/alerting/client/Dockerfile
+++ b/observability/alerting/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.21
 COPY . /usr/src/client/
 WORKDIR /usr/src/client/
 RUN go env -w GOPROXY=direct

--- a/observability/alerting/docker-compose.yaml
+++ b/observability/alerting/docker-compose.yaml
@@ -4,10 +4,12 @@ services:
   # Jaeger
   jaeger-all-in-one:
     image: jaegertracing/all-in-one:latest
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"
-      - "14268"
-      - "14250"
+      - "4317"
+      - "4318"
 
   # Collector
   otel-collector:

--- a/observability/alerting/otel-collector-config.yaml
+++ b/observability/alerting/otel-collector-config.yaml
@@ -10,8 +10,8 @@ exporters:
       label1: value1
   logging:
 
-  jaeger:
-    endpoint: jaeger-all-in-one:14250
+  otlp:
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
 
@@ -23,7 +23,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, jaeger]
+      exporters: [logging, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]

--- a/observability/alerting/server/Dockerfile
+++ b/observability/alerting/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.21
 COPY . /usr/src/server/
 WORKDIR /usr/src/server/
 RUN go env -w GOPROXY=direct

--- a/observability/alerting/server/main.go
+++ b/observability/alerting/server/main.go
@@ -46,7 +46,7 @@ func main() {
 // artificial request latency.
 func handleRequestWithRandomSleep(meterProvider *sdkmetric.MeterProvider) http.HandlerFunc {
 	var (
-		meter        = meterProvider.Meter("demo_client", metric.WithInstrumentationVersion("v1.0.0"))
+		meter        = meterProvider.Meter("demo_server", metric.WithInstrumentationVersion("v1.0.0"))
 		instruments  = NewServerInstruments(meter)
 		commonLabels = []attribute.KeyValue{
 			attribute.String("server-attribute", "foo"),
@@ -157,7 +157,7 @@ func initMetrics(ctx context.Context, otelAgentAddr string) (*sdkmetric.MeterPro
 		resource.WithHost(),
 		resource.WithAttributes(
 			// the service name used to display traces in backends
-			semconv.ServiceNameKey.String("demo-client"),
+			semconv.ServiceNameKey.String("demo-server"),
 		),
 	)
 

--- a/observability/metrics/.env
+++ b/observability/metrics/.env
@@ -1,2 +1,2 @@
-OTELCOL_IMG=otel/opentelemetry-collector-contrib-dev:latest
+OTELCOL_IMG=otel/opentelemetry-collector:latest
 OTELCOL_ARGS=

--- a/observability/metrics/client/Dockerfile
+++ b/observability/metrics/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.21
 COPY . /usr/src/client/
 WORKDIR /usr/src/client/
 RUN go env -w GOPROXY=direct

--- a/observability/metrics/docker-compose.yaml
+++ b/observability/metrics/docker-compose.yaml
@@ -4,10 +4,12 @@ services:
   # Jaeger
   jaeger-all-in-one:
     image: jaegertracing/all-in-one:latest
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"
-      - "14268"
-      - "14250"
+      - "4317"
+      - "4318"
 
   # Collector
   otel-collector:

--- a/observability/metrics/otel-collector-config.yaml
+++ b/observability/metrics/otel-collector-config.yaml
@@ -10,8 +10,8 @@ exporters:
       label1: value1
   logging:
 
-  jaeger:
-    endpoint: jaeger-all-in-one:14250
+  otlp:
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
 
@@ -23,7 +23,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, jaeger]
+      exporters: [logging, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]

--- a/observability/metrics/server/Dockerfile
+++ b/observability/metrics/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.21
 COPY . /usr/src/server/
 WORKDIR /usr/src/server/
 RUN go env -w GOPROXY=direct

--- a/observability/tracing/client/Dockerfile
+++ b/observability/tracing/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.21
 COPY . /usr/src/client/
 WORKDIR /usr/src/client/
 RUN go env -w GOPROXY=direct

--- a/observability/tracing/docker-compose.yaml
+++ b/observability/tracing/docker-compose.yaml
@@ -1,17 +1,19 @@
-version: "2"
+version: "3.8"
 services:
 
   # Jaeger
   jaeger-all-in-one:
     image: jaegertracing/all-in-one:latest
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
     ports:
       - "16686:16686"
-      - "14268"
-      - "14250"
+      - "4317"
+      - "4318"
 
   # Collector
   otel-collector:
-    image: ${OTELCOL_IMG}
+    image: otel/opentelemetry-collector:latest
     command: ["--config=/etc/otel-collector-config.yaml", "${OTELCOL_ARGS}"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
@@ -32,6 +34,7 @@ services:
       - DEMO_SERVER_ENDPOINT=http://demo-server:7080/hello
     depends_on:
       - demo-server
+      - otel-collector
 
   demo-server:
     build:

--- a/observability/tracing/otel-collector-config.yaml
+++ b/observability/tracing/otel-collector-config.yaml
@@ -4,8 +4,8 @@ receivers:
       grpc:
 
 exporters:
-  jaeger:
-    endpoint: jaeger-all-in-one:14250
+  otlp:
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
 
@@ -17,5 +17,5 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [jaeger]
+      exporters: [otlp]
 

--- a/observability/tracing/server/Dockerfile
+++ b/observability/tracing/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.21
 COPY . /usr/src/server/
 WORKDIR /usr/src/server/
 RUN go env -w GOPROXY=direct


### PR DESCRIPTION
There were some out of date images in use as well as configuration. This PR updates the image used by the collector and transitions the tracing stack to completely using otlp for the wire protocol. Beyond that, there are updates to service naming and Go version.